### PR TITLE
Fixed example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ The most basic usage:
 ```js
 require('check-dependencies')(callback);
 ```
-This will check packages' versions, install mismatched ones and invoke `callback`.
+This will check packages' versions and report an error to `callback` if packages' versions are mismatched.
 
 The following:
 ```js
 require('check-dependencies')({
-    install: false,
+    install: true,
     verbose: true,
 }, callback);
 ```
-will report an error to `callback` if packages' versions are mismatched.
+will install mismatched ones and call `callback`.
 
 The following two examples:
 ```js


### PR DESCRIPTION
Hi,

This is my first time using your module and I think there is a tiny error in the README.

If I got it right, the default value for `install` is [false](https://github.com/mzgol/check-dependencies/blob/master/lib/check-dependencies.js#L36) but from the examples one could think the inverse.

Great work btw!

Regards,
Guilherme
