### PR TITLE
Support nested node module resolution

### DIFF
--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -132,10 +132,11 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
         const name = pkg.name;
         let versionString = pkg.versionString;
 
-        const depDir = `${ depsDir }/${ name }`;
-        const depJson = `${ depDir }/${ depsJsonName }`;
+        const findupConfig = {cwd: options.packageDir};
+        const depDir = findup(`${ depsDirName }/${ name }`, findupConfig);
+        const depJson = findup(`${ depDir }/${ depsJsonName }`, findupConfig);
 
-        if (!fs.existsSync(depDir) || !fs.existsSync(depJson)) {
+        if (!depDir || !depJson) {
             if (pkg.isOptional) {
                 log(`${ name }: ${ chalk.red('not installed!') }`);
             } else {

--- a/test/npm-fixtures/ok/nested-package/package.json
+++ b/test/npm-fixtures/ok/nested-package/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "a": "1.2.3"
+    }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -283,6 +283,18 @@ describe('checkDependencies', () => {
                 });
             });
 
+            it('should not print errors for valid package setup in nested package', done => {
+                checkDeps({
+                    packageDir: `${ fixturePrefixSeparate }ok/nested-package`,
+                    scopeList: ['dependencies', 'devDependencies'],
+                }, output => {
+                    assert.deepEqual(output.error, []);
+                    assert.strictEqual(output.depsWereOk, true);
+                    assert.strictEqual(output.status, 0);
+                    done();
+                });
+            });
+
             if (checkDependenciesMode === 'callback') {
                 it('should throw if config not present and callback is not a function', () => {
                     const expectToThrow = fnsWithReasons => {


### PR DESCRIPTION
This change allows for npm packages to be resolved in parent directories.

For example, the following directory structure would satisfy a dependency check in the `packages/my-package` directory:

```
├── node_modules
│   └── some-npm-module
└── packages
    └── my-package
        └── package.json (includes some-npm-module dependency)
```

This allows for checking dependencies in monorepo repositories managed with with [Lerna](https://github.com/lerna/lerna), especially when the [hoist](https://github.com/lerna/lerna/blob/master/doc/hoist.md) option is used. This is consistent with node's module resolution technique (see Lerna hoist documentation, and [node documentation](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders)).

Thanks!