### PR TITLE
Feature support NPM package aliases

### DIFF
--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -104,6 +104,9 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
         return finish();
     };
 
+    const supportsPackageAliases = packageManager =>
+        packageManager === 'npm' || packageManager === 'yarn';
+
     options.packageDir = options.packageDir || findup(packageJsonName);
     if (!options.packageDir) {
         return missingPackageJson();
@@ -204,21 +207,13 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
 
         const depJson = require(depJsonPath);
 
-        // Support npm package aliases
+        // Support package aliases
         if (
-            options.packageManager === 'npm' &&
-            depJson &&
-            depJson._requested &&
-            depJson._requested.type === 'alias'
+            supportsPackageAliases(options.packageManager) &&
+            /npm:(.+)@(.+)/.test(versionString)
         ) {
-            const [, depName, version] =
-                versionString.match(/npm:(.+)@(.+)/) || [];
+            const [, depName, version] = versionString.match(/npm:(.+)@(.+)/);
 
-            if (!depName || !version) {
-                error(
-                    `${name} is defined as an aliased package, but it does not match the known structure: "npm:source-name@version"`,
-                );
-            }
             versionString = version;
 
             if (depJson.name !== depName) {

--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -152,9 +152,9 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
         let versionString = pkg.versionString;
 
         const depDir = `${depsDir}/${name}`;
-        const depJson = `${depDir}/${depsJsonName}`;
+        const depJsonPath = `${depDir}/${depsJsonName}`;
 
-        if (!fs.existsSync(depDir) || !fs.existsSync(depJson)) {
+        if (!fs.existsSync(depDir) || !fs.existsSync(depJsonPath)) {
             if (pkg.isOptional) {
                 log(`${name}: ${chalk.red('not installed!')}`);
             } else {
@@ -202,7 +202,36 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
             return;
         }
 
-        const depVersion = require(depJson).version;
+        const depJson = require(depJsonPath);
+
+        // Support NPM package aliases
+        if (
+            options.packageManager === 'npm' &&
+            depJson &&
+            depJson._requested &&
+            depJson._requested.type === 'alias'
+        ) {
+            const [, depName, version] =
+                versionString.match(/npm:(.+)@(.+)/) || [];
+
+            if (!depName || !version) {
+                error(
+                    `${name} is defined as an aliased package, but it does not match the known structure: "npm:source-name@version"`,
+                );
+            }
+            versionString = version;
+
+            if (depJson.name !== depName) {
+                success = false;
+                error(
+                    `${name}: installed: ${chalk.red(
+                        depName,
+                    )}, expected: ${chalk.green(depJson.name)}`,
+                );
+            }
+        }
+
+        const depVersion = depJson.version;
         if (semver.satisfies(depVersion, versionString)) {
             log(
                 `${name}: installed: ${chalk.green(

--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -204,7 +204,7 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
 
         const depJson = require(depJsonPath);
 
-        // Support NPM package aliases
+        // Support npm package aliases
         if (
             options.packageManager === 'npm' &&
             depJson &&

--- a/test/npm-fixtures/ok/node_modules/c-alias/package.json
+++ b/test/npm-fixtures/ok/node_modules/c-alias/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "c",
+    "version": "1.2.3",
+    "_requested": {
+        "type": "alias"
+    }
+}

--- a/test/npm-fixtures/ok/package.json
+++ b/test/npm-fixtures/ok/package.json
@@ -4,6 +4,7 @@
         "a": "1.2.3",
         "b": ">=1.0.0",
         "c": "<2.0",
+        "c-alias": "npm:c@<2.0",
         "d": "git+ssh://git@git.example.com:d/d.git#0.5.9",
         "@e-f/g-h": "~2.5.7"
     }

--- a/test/spec.js
+++ b/test/spec.js
@@ -987,6 +987,7 @@ describe('checkDependencies', () => {
                                 'a: installed: 1.2.3, expected: 1.2.3',
                                 'b: installed: 1.2.3, expected: >=1.0.0',
                                 'c: installed: 1.2.3, expected: <2.0',
+                                'c-alias: installed: 1.2.3, expected: <2.0',
                                 '@e-f/g-h: installed: 2.5.9, expected: ~2.5.7',
                                 '',
                             ].join('\n'),


### PR DESCRIPTION
NPM has a poorly documented aliasing feature allowing user to install multiple instances of the same package under different names.
Proposal: https://github.com/npm/rfcs/blob/latest/implemented/0001-package-aliases.md
Implementation: https://github.com/npm/cli/pull/3

Add support for these aliases, checking the installed version and if dependency matches by name.