### PR TITLE
Support npm package aliases

### DIFF
--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -152,9 +152,9 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
         let versionString = pkg.versionString;
 
         const depDir = `${depsDir}/${name}`;
-        const depJson = `${depDir}/${depsJsonName}`;
+        const depJsonPath = `${depDir}/${depsJsonName}`;
 
-        if (!fs.existsSync(depDir) || !fs.existsSync(depJson)) {
+        if (!fs.existsSync(depDir) || !fs.existsSync(depJsonPath)) {
             if (pkg.isOptional) {
                 log(`${name}: ${chalk.red('not installed!')}`);
             } else {
@@ -202,7 +202,28 @@ const checkDependenciesHelper = (syncOrAsync, config, callback) => {
             return;
         }
 
-        const depVersion = require(depJson).version;
+        const depJson = require(depJsonPath);
+
+        // Support package aliases
+        if (
+            options.packageManager !== 'bower' &&
+            /npm:(.+)@(.+)/.test(versionString)
+        ) {
+            const [, depName, version] = versionString.match(/npm:(.+)@(.+)/);
+
+            versionString = version;
+
+            if (depJson.name !== depName) {
+                success = false;
+                error(
+                    `${name}: installed: ${chalk.red(
+                        depName,
+                    )}, expected: ${chalk.green(depJson.name)}`,
+                );
+            }
+        }
+
+        const depVersion = depJson.version;
         if (semver.satisfies(depVersion, versionString)) {
             log(
                 `${name}: installed: ${chalk.green(

--- a/test/npm-fixtures/ok/node_modules/c-alias/package.json
+++ b/test/npm-fixtures/ok/node_modules/c-alias/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "c",
+    "version": "1.2.3",
+    "_requested": {
+        "type": "alias"
+    }
+}

--- a/test/npm-fixtures/ok/package.json
+++ b/test/npm-fixtures/ok/package.json
@@ -4,6 +4,7 @@
         "a": "1.2.3",
         "b": ">=1.0.0",
         "c": "<2.0",
+        "c-alias": "npm:c@<2.0",
         "d": "git+ssh://git@git.example.com:d/d.git#0.5.9",
         "@e-f/g-h": "~2.5.7"
     }

--- a/test/spec.js
+++ b/test/spec.js
@@ -987,6 +987,7 @@ describe('checkDependencies', () => {
                                 'a: installed: 1.2.3, expected: 1.2.3',
                                 'b: installed: 1.2.3, expected: >=1.0.0',
                                 'c: installed: 1.2.3, expected: <2.0',
+                                'c-alias: installed: 1.2.3, expected: <2.0',
                                 '@e-f/g-h: installed: 2.5.9, expected: ~2.5.7',
                                 '',
                             ].join('\n'),


### PR DESCRIPTION
This PR has exactly the same changes as #45 except that, as requested, it supports all package managers except bower, rather than only supporting npm and yarn.